### PR TITLE
issue-3 fix static css, js files at http://127.0.0.1:8001/admin/

### DIFF
--- a/bot_conf/urls.py
+++ b/bot_conf/urls.py
@@ -1,10 +1,12 @@
 from django.conf.urls import url
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
 
     # path('payment/', include(('payment.urls', 'payment'), namespace='payment')),
 
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
All static files have error 404.
/static/admin/css/base.css - Page not found (404)
...
Fix:
from django.conf import settings
from django.conf.urls.static import static

urlpatterns = [
...
] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)